### PR TITLE
refactor[ci]: adapt to pre-pack and publish package

### DIFF
--- a/.github/jobactions/npm-prepare-publish/action.yml
+++ b/.github/jobactions/npm-prepare-publish/action.yml
@@ -10,6 +10,13 @@ inputs:
     default: ${{ github.repository_owner }}
   token:
     required: true
+outputs:
+  package:
+    description: package name (without path)
+    value: ${{ steps.npm-pack.outputs.package }}
+  package-full:
+    description: package name with path
+    value: ${{ steps.npm-pack.outputs.package_full }}
 runs:
   using: composite
   steps:

--- a/.github/jobactions/npm-prepare-publish/action.yml
+++ b/.github/jobactions/npm-prepare-publish/action.yml
@@ -22,9 +22,8 @@ runs:
       token: ${{ inputs.token }}
   - uses: ./.github/jobactions/build
     with:
-      framework: net8.0
+      unity: 2022.3
       configuration: Release
-      exclude: Prototype
   - uses: kagekirin/gha-npm/.github/actions/npm-pack@main
     with:
       framework: net8.0

--- a/.github/jobactions/npm-prepare-publish/action.yml
+++ b/.github/jobactions/npm-prepare-publish/action.yml
@@ -24,6 +24,9 @@ runs:
     with:
       unity: 2022.3
       configuration: Release
-  - uses: kagekirin/gha-npm/.github/actions/npm-pack@main
+  - id: npm-pack
+    uses: kagekirin/gha-npm/.github/actions/npm-pack@main
     with:
-      framework: net8.0
+      path: ${{ github.workspace }}
+      spec: package.json
+      outdir: ./

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -53,7 +53,7 @@ jobs:
             username: ${{ github.repository_owner }}
             token: NPMJS_ORG_TOKEN
           - source: github
-            registry: https://npm.pkg.github.com/@${{ github.repository_owner }}
+            registry: https://npm.github.com/@${{ github.repository_owner }}
             username: ${{ github.repository_owner }}
             token: GH_NPM_TOKEN
     needs: build

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -59,16 +59,17 @@ jobs:
     needs: build
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
-    - uses: ./.github/jobactions/npm-prepare-publish
+    - id: npm-prepare-publish
+      uses: ./.github/jobactions/npm-prepare-publish
       with:
         name: ${{ matrix.source }}
         registry: ${{ matrix.registry }}
         username: ${{ matrix.username }}
         token: ${{ secrets[matrix.token] }}
-    - uses: kagekirin/gha-npm/.github/actions/npm-publish@main
+    - uses: kagekirin/gha-npm/.github/actions/npm-publish-package@main
       with:
         registry: ${{ matrix.registry }}
-        token: ${{ secrets[matrix.token] }}
+        package: ${{ steps.npm-prepare-publish.outputs.package_full }}
         dry-run: true
 
   tag:

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -54,14 +54,15 @@ jobs:
     needs: build
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
-    - uses: ./.github/jobactions/npm-prepare-publish
+    - id: npm-prepare-publish
+      uses: ./.github/jobactions/npm-prepare-publish
       with:
         name: ${{ matrix.source }}
         registry: ${{ matrix.registry }}
         username: ${{ matrix.username }}
         token: ${{ secrets[matrix.token] }}
-    - uses: kagekirin/gha-npm/.github/actions/npm-publish@main
+    - uses: kagekirin/gha-npm/.github/actions/npm-publish-package@main
       with:
         registry: ${{ matrix.registry }}
-        token: ${{ secrets[matrix.token] }}
+        package: ${{ steps.npm-prepare-publish.outputs.package_full }}
         dry-run: true

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -48,7 +48,7 @@ jobs:
             username: ${{ github.repository_owner }}
             token: NPMJS_ORG_TOKEN
           - source: github
-            registry: https://npm.pkg.github.com/@${{ github.repository_owner }}
+            registry: https://npm.github.com/@${{ github.repository_owner }}
             username: ${{ github.repository_owner }}
             token: GH_NPM_TOKEN
     needs: build

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -51,7 +51,7 @@ jobs:
             username: ${{ github.repository_owner }}
             token: NPMJS_ORG_TOKEN
           - source: github
-            registry: https://npm.pkg.github.com/@${{ github.repository_owner }}
+            registry: https://npm.github.com/@${{ github.repository_owner }}
             username: ${{ github.repository_owner }}
             token: GH_NPM_TOKEN
     needs: build

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -57,14 +57,15 @@ jobs:
     needs: build
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
-    - uses: ./.github/jobactions/npm-prepare-publish
+    - id: npm-prepare-publish
+      uses: ./.github/jobactions/npm-prepare-publish
       with:
         name: ${{ matrix.source }}
         registry: ${{ matrix.registry }}
         username: ${{ matrix.username }}
         token: ${{ secrets[matrix.token] }}
-    - uses: kagekirin/gha-npm/.github/actions/npm-publish@main
+    - uses: kagekirin/gha-npm/.github/actions/npm-publish-package@main
       with:
         registry: ${{ matrix.registry }}
-        token: ${{ secrets[matrix.token] }}
+        package: ${{ steps.npm-prepare-publish.outputs.package_full }}
         dry-run: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,14 +22,15 @@ jobs:
             token: GH_NPM_TOKEN
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
-    - uses: ./.github/jobactions/npm-prepare-publish
+    - id: npm-prepare-publish
+      uses: ./.github/jobactions/npm-prepare-publish
       with:
         name: ${{ matrix.source }}
         registry: ${{ matrix.registry }}
         username: ${{ matrix.username }}
         token: ${{ secrets[matrix.token] }}
-    - uses: kagekirin/gha-npm/.github/actions/npm-publish@main
+    - uses: kagekirin/gha-npm/.github/actions/npm-publish-package@main
       with:
         registry: ${{ matrix.registry }}
-        token: ${{ secrets[matrix.token] }}
+        package: ${{ steps.npm-prepare-publish.outputs.package_full }}
         dry-run: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
             username: ${{ github.repository_owner }}
             token: NPMJS_ORG_TOKEN
           - source: github
-            registry: https://npm.pkg.github.com/@${{ github.repository_owner }}
+            registry: https://npm.github.com/@${{ github.repository_owner }}
             username: ${{ github.repository_owner }}
             token: GH_NPM_TOKEN
     steps:


### PR DESCRIPTION
- **fix[ci] ('build-pr' workflow): use correct GitHub NPM registry URL**
- **fix[ci] ('build-ci' workflow): use correct GitHub NPM registry URL**
- **fix[ci] ('build-cron' workflow): use correct GitHub NPM registry URL**
- **fix[ci] ('publish' workflow): use correct GitHub NPM registry URL**
- **fix[ci] ('npm-prepare-publish' action): adapt 'build' step parameters**
- **fix[ci] ('npm-prepare-publish' action): adapt 'npm-pack' step parameters**
- **feature[ci] ('npm-prepare-publish' action): return outputs from 'npm-pack' step**
- **refactor[ci] ('build-pr' workflow): publish (dry-run) pre-packed package**
- **refactor[ci] ('build-ci' workflow): publish (dry-run) pre-packed package**
- **refactor[ci] ('build-cron' workflow): publish (dry-run) pre-packed package**
- **refactor[ci] ('publish' workflow): publish pre-packed package**
