### PR TITLE
fix[ci]: set and use variable 'package-full' instead of 'package_full'

### DIFF
--- a/.github/jobactions/npm-prepare-publish/action.yml
+++ b/.github/jobactions/npm-prepare-publish/action.yml
@@ -13,7 +13,7 @@ outputs:
     value: ${{ steps.npm-pack.outputs.package }}
   package-full:
     description: package name with path
-    value: ${{ steps.npm-pack.outputs.package_full }}
+    value: ${{ steps.npm-pack.outputs.package-full }}
 runs:
   using: composite
   steps:

--- a/.github/jobactions/npm-prepare-publish/action.yml
+++ b/.github/jobactions/npm-prepare-publish/action.yml
@@ -5,9 +5,6 @@ inputs:
   registry:
     required: false
     default: https://npm.pkg.github.com/${{ github.repository_owner }}/index.json
-  username:
-    required: false
-    default: ${{ github.repository_owner }}
   token:
     required: true
 outputs:
@@ -25,7 +22,6 @@ runs:
     with:
       name: ${{ inputs.name }}
       registry: ${{ inputs.registry }}
-      username: ${{ inputs.username }}
       token: ${{ inputs.token }}
   - uses: ./.github/jobactions/build
     with:

--- a/.github/jobactions/tag/action.yml
+++ b/.github/jobactions/tag/action.yml
@@ -41,6 +41,7 @@ runs:
       echo "Version: $version"
 
       node-package-version set --version $version package.json
+      npm pkg fix
       git commit -am "tag: v$version"
       git tag -f v$version
 

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -68,7 +68,7 @@ jobs:
     - uses: kagekirin/gha-npm/.github/actions/npm-publish-package@main
       with:
         registry: ${{ matrix.registry }}
-        package: ${{ steps.npm-prepare-publish.outputs.package_full }}
+        package: ${{ steps.npm-prepare-publish.outputs.package-full }}
         dry-run: true
 
   tag:

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -64,7 +64,6 @@ jobs:
       with:
         name: ${{ matrix.source }}
         registry: ${{ matrix.registry }}
-        username: ${{ matrix.username }}
         token: ${{ secrets[matrix.token] }}
     - uses: kagekirin/gha-npm/.github/actions/npm-publish-package@main
       with:

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -59,7 +59,6 @@ jobs:
       with:
         name: ${{ matrix.source }}
         registry: ${{ matrix.registry }}
-        username: ${{ matrix.username }}
         token: ${{ secrets[matrix.token] }}
     - uses: kagekirin/gha-npm/.github/actions/npm-publish-package@main
       with:

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -63,5 +63,5 @@ jobs:
     - uses: kagekirin/gha-npm/.github/actions/npm-publish-package@main
       with:
         registry: ${{ matrix.registry }}
-        package: ${{ steps.npm-prepare-publish.outputs.package_full }}
+        package: ${{ steps.npm-prepare-publish.outputs.package-full }}
         dry-run: true

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -62,7 +62,6 @@ jobs:
       with:
         name: ${{ matrix.source }}
         registry: ${{ matrix.registry }}
-        username: ${{ matrix.username }}
         token: ${{ secrets[matrix.token] }}
     - uses: kagekirin/gha-npm/.github/actions/npm-publish-package@main
       with:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -66,5 +66,5 @@ jobs:
     - uses: kagekirin/gha-npm/.github/actions/npm-publish-package@main
       with:
         registry: ${{ matrix.registry }}
-        package: ${{ steps.npm-prepare-publish.outputs.package_full }}
+        package: ${{ steps.npm-prepare-publish.outputs.package-full }}
         dry-run: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,6 @@ jobs:
       with:
         name: ${{ matrix.source }}
         registry: ${{ matrix.registry }}
-        username: ${{ matrix.username }}
         token: ${{ secrets[matrix.token] }}
     - uses: kagekirin/gha-npm/.github/actions/npm-publish-package@main
       with:
@@ -57,7 +56,6 @@ jobs:
       with:
         name: ${{ matrix.source }}
         registry: ${{ matrix.registry }}
-        username: ${{ matrix.username }}
         token: ${{ secrets[matrix.token] }}
     - uses: kagekirin/gha-npm/.github/actions/npm-publish-package@main
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: kagekirin/gha-npm/.github/actions/npm-publish-package@main
       with:
         registry: ${{ matrix.registry }}
-        package: ${{ steps.npm-prepare-publish.outputs.package_full }}
+        package: ${{ steps.npm-prepare-publish.outputs.package-full }}
         dry-run: true
 
   npm:
@@ -60,5 +60,5 @@ jobs:
     - uses: kagekirin/gha-npm/.github/actions/npm-publish-package@main
       with:
         registry: ${{ matrix.registry }}
-        package: ${{ steps.npm-prepare-publish.outputs.package_full }}
+        package: ${{ steps.npm-prepare-publish.outputs.package-full }}
         dry-run: false


### PR DESCRIPTION
- **refactor[ci] ('npm-prepare-publish' jobaction): remove unused parameter 'username'**
  

- **fix[ci] ('npm-prepare-publish' jobaction): set correct output variable for 'package-full'**
  detail: was 'package_full', but 'package-full' is correct
  

- **fix[ci] ('build-pr' workflow): fix value of parameter 'package' passed to 'npm-publish-package' step**
  detail: 'steps.npm-prepare-publish.outputs.package-full' instead of 'steps.npm-prepare-publish.outputs.package_full'
  

- **fix[ci] ('build-ci' workflow): fix value of parameter 'package' passed to 'npm-publish-package' step**
  detail: 'steps.npm-prepare-publish.outputs.package-full' instead of 'steps.npm-prepare-publish.outputs.package_full'
  

- **fix[ci] ('build-cron' workflow): fix value of parameter 'package' passed to 'npm-publish-package' step**
  detail: 'steps.npm-prepare-publish.outputs.package-full' instead of 'steps.npm-prepare-publish.outputs.package_full'
  

- **fix[ci] ('publish' workflow): fix value of parameter 'package' passed to 'npm-publish-package' step**
  detail: 'steps.npm-prepare-publish.outputs.package-full' instead of 'steps.npm-prepare-publish.outputs.package_full'
  

- **feature[ci] ('tag' jobaction): automatically fix package.json after setting version**
  