### PR TITLE
refactor[ci] (workflows): pass package name without path

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -68,7 +68,7 @@ jobs:
     - uses: kagekirin/gha-npm/.github/actions/npm-publish-package@main
       with:
         registry: ${{ matrix.registry }}
-        package: ${{ steps.npm-prepare-publish.outputs.package-full }}
+        package: ${{ steps.npm-prepare-publish.outputs.package }}
         dry-run: true
 
   tag:

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -63,5 +63,5 @@ jobs:
     - uses: kagekirin/gha-npm/.github/actions/npm-publish-package@main
       with:
         registry: ${{ matrix.registry }}
-        package: ${{ steps.npm-prepare-publish.outputs.package-full }}
+        package: ${{ steps.npm-prepare-publish.outputs.package }}
         dry-run: true

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -66,5 +66,5 @@ jobs:
     - uses: kagekirin/gha-npm/.github/actions/npm-publish-package@main
       with:
         registry: ${{ matrix.registry }}
-        package: ${{ steps.npm-prepare-publish.outputs.package-full }}
+        package: ${{ steps.npm-prepare-publish.outputs.package }}
         dry-run: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: kagekirin/gha-npm/.github/actions/npm-publish-package@main
       with:
         registry: ${{ matrix.registry }}
-        package: ${{ steps.npm-prepare-publish.outputs.package-full }}
+        package: ${{ steps.npm-prepare-publish.outputs.package }}
         dry-run: true
 
   npm:
@@ -60,5 +60,5 @@ jobs:
     - uses: kagekirin/gha-npm/.github/actions/npm-publish-package@main
       with:
         registry: ${{ matrix.registry }}
-        package: ${{ steps.npm-prepare-publish.outputs.package-full }}
+        package: ${{ steps.npm-prepare-publish.outputs.package }}
         dry-run: false


### PR DESCRIPTION
- **refactor[ci] ('build-pr' workflow): pass package name without path**
  reason: package is a root folder anyway
  

- **refactor[ci] ('build-ci' workflow): pass package name without path**
  reason: package is a root folder anyway
  

- **refactor[ci] ('build-cron' workflow): pass package name without path**
  reason: package is a root folder anyway
  

- **refactor[ci] ('publish' workflow): pass package name without path**
  reason: package is a root folder anyway
  