### PR TITLE
refactor (ci workflows): use 'npm-publish' action instead of 'npm-publish-package'

### DIFF
--- a/.github/jobactions/npm-prepare-publish/action.yml
+++ b/.github/jobactions/npm-prepare-publish/action.yml
@@ -40,7 +40,7 @@ runs:
     with:
       path: ${{ github.workspace }}
       spec: package.json
-      registry: ${{ inputs.registry-url }}
+      registry-url: ${{ inputs.registry-url }}
       scope: ${{ inputs.scope }}
 
   - uses: ./.github/jobactions/build

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -67,9 +67,9 @@ jobs:
         registry-url: ${{ matrix.registry-url }}
         scope: ${{ matrix.scope }}
         token: ${{ secrets[matrix.token] }}
-    - uses: kagekirin/gha-npm/.github/actions/npm-publish-package@main
+    - uses: kagekirin/gha-npm/.github/actions/npm-publish@main
       with:
-        package: ${{ steps.npm-prepare-publish.outputs.package }}
+        spec: package.json
         token: ${{ secrets[matrix.token] }}
         dry-run: true
 

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -62,8 +62,8 @@ jobs:
         registry-url: ${{ matrix.registry-url }}
         scope: ${{ matrix.scope }}
         token: ${{ secrets[matrix.token] }}
-    - uses: kagekirin/gha-npm/.github/actions/npm-publish-package@main
+    - uses: kagekirin/gha-npm/.github/actions/npm-publish@main
       with:
-        package: ${{ steps.npm-prepare-publish.outputs.package }}
+        spec: package.json
         token: ${{ secrets[matrix.token] }}
         dry-run: true

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -65,8 +65,8 @@ jobs:
         registry-url: ${{ matrix.registry-url }}
         scope: ${{ matrix.scope }}
         token: ${{ secrets[matrix.token] }}
-    - uses: kagekirin/gha-npm/.github/actions/npm-publish-package@main
+    - uses: kagekirin/gha-npm/.github/actions/npm-publish@main
       with:
-        package: ${{ steps.npm-prepare-publish.outputs.package }}
+        spec: package.json
         token: ${{ secrets[matrix.token] }}
         dry-run: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
         source: [github, npmjs]
         include:
           - source: github
-            registry: https://npm.pkg.github.com/
+            registry-url: https://npm.pkg.github.com/
             scope: 'kagekirin'                        #must be lowercase, without '@'
             username: ${{ github.repository_owner }}  #not lowercase
             token: GH_NPM_TOKEN
@@ -27,7 +27,7 @@ jobs:
     - id: npm-prepare-publish
       uses: ./.github/jobactions/npm-prepare-publish
       with:
-        registry: ${{ matrix.registry }}
+        registry-url: ${{ matrix.registry-url }}
         scope: ${{ matrix.scope }}
         token: ${{ secrets[matrix.token] }}
     - uses: kagekirin/gha-npm/.github/actions/npm-publish@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,9 +30,9 @@ jobs:
         registry: ${{ matrix.registry }}
         scope: ${{ matrix.scope }}
         token: ${{ secrets[matrix.token] }}
-    - uses: kagekirin/gha-npm/.github/actions/npm-publish-package@main
+    - uses: kagekirin/gha-npm/.github/actions/npm-publish@main
       with:
-        package: ${{ steps.npm-prepare-publish.outputs.package }}
+        spec: package.json
         token: ${{ secrets[matrix.token] }}
         dry-run: true
 
@@ -61,8 +61,8 @@ jobs:
         registry-url: ${{ matrix.registry-url }}
         scope: ${{ matrix.scope }}
         token: ${{ secrets[matrix.token] }}
-    - uses: kagekirin/gha-npm/.github/actions/npm-publish-package@main
+    - uses: kagekirin/gha-npm/.github/actions/npm-publish@main
       with:
-        package: ${{ steps.npm-prepare-publish.outputs.package }}
+        spec: package.json
         token: ${{ secrets[matrix.token] }}
         dry-run: false

--- a/.gitignore
+++ b/.gitignore
@@ -481,3 +481,6 @@ $RECYCLE.BIN/
 
 # Vim temporary swap files
 *.swp
+
+# NPM Packages
+*.tgz


### PR DESCRIPTION
- **repo: gitignore *.tgz files ('npm pack' artifacts)**
  

- **refactor ('build-pr' workflow): use 'npm-publish' action instead of 'npm-publish-package'**
  

- **refactor ('build-ci' workflow): use 'npm-publish' action instead of 'npm-publish-package'**
  

- **refactor ('build-cron' workflow): use 'npm-publish' action instead of 'npm-publish-package'**
  

- **refactor ('publish' workflow): use 'npm-publish' action instead of 'npm-publish-package'**
  

- **fix ('publish' workflow): fix variable misnomer, 'registry-url' instead of 'registry'**
  

- **fix ('npm-prepare-publish' jobaction): fix variable misnomer, 'registry-url' instead of 'registry'**
  note: input in underlying 'gha-npm/npm-patch-spec-registry' has changed
  