### PR TITLE
refactor (ci workflows): remove NPMJS from test-npm/npm matrix parameters

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -44,6 +44,9 @@ jobs:
   test-npm:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # allow GITHUB_TOKEN to publish packages
     strategy:
       matrix:
         source: [github, npmjs]

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -56,11 +56,6 @@ jobs:
             scope: 'kagekirin'                        #must be lowercase, without '@'
             username: ${{ github.repository_owner }}  #not lowercase
             token: GH_NPM_TOKEN
-          - source: npmjs
-            registry-url: https://registry.npmjs.org/
-            scope: 'kagekirin'                        #must be lowercase, without '@'
-            username: ${{ github.repository_owner }}  #not lowercase
-            token: NPMJS_ORG_TOKEN
     needs: build
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -49,7 +49,7 @@ jobs:
       packages: write # allow GITHUB_TOKEN to publish packages
     strategy:
       matrix:
-        source: [github, npmjs]
+        source: [github]
         include:
           - source: github
             registry-url: https://npm.pkg.github.com/

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -55,7 +55,7 @@ jobs:
             registry-url: https://npm.pkg.github.com/
             scope: 'kagekirin'                        #must be lowercase, without '@'
             username: ${{ github.repository_owner }}  #not lowercase
-            token: GH_NPM_TOKEN
+            token: GITHUB_TOKEN
     needs: build
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -39,6 +39,9 @@ jobs:
 
   test-npm:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # allow GITHUB_TOKEN to publish packages
     strategy:
       matrix:
         source: [github, npmjs]

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -50,7 +50,7 @@ jobs:
             registry-url: https://npm.pkg.github.com/
             scope: 'kagekirin'                        #must be lowercase, without '@'
             username: ${{ github.repository_owner }}  #not lowercase
-            token: GH_NPM_TOKEN
+            token: GITHUB_TOKEN
     needs: build
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -51,11 +51,6 @@ jobs:
             scope: 'kagekirin'                        #must be lowercase, without '@'
             username: ${{ github.repository_owner }}  #not lowercase
             token: GH_NPM_TOKEN
-          - source: npmjs
-            registry-url: https://registry.npmjs.org/
-            scope: 'kagekirin'                        #must be lowercase, without '@'
-            username: ${{ github.repository_owner }}  #not lowercase
-            token: NPMJS_ORG_TOKEN
     needs: build
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -44,7 +44,7 @@ jobs:
       packages: write # allow GITHUB_TOKEN to publish packages
     strategy:
       matrix:
-        source: [github, npmjs]
+        source: [github]
         include:
           - source: github
             registry-url: https://npm.pkg.github.com/

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -54,11 +54,6 @@ jobs:
             scope: 'kagekirin'                        #must be lowercase, without '@'
             username: ${{ github.repository_owner }}  #not lowercase
             token: GH_NPM_TOKEN
-          - source: npmjs
-            registry-url: https://registry.npmjs.org/
-            scope: 'kagekirin'                        #must be lowercase, without '@'
-            username: ${{ github.repository_owner }}  #not lowercase
-            token: NPMJS_ORG_TOKEN
     needs: build
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -53,7 +53,7 @@ jobs:
             registry-url: https://npm.pkg.github.com/
             scope: 'kagekirin'                        #must be lowercase, without '@'
             username: ${{ github.repository_owner }}  #not lowercase
-            token: GH_NPM_TOKEN
+            token: GITHUB_TOKEN
     needs: build
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -47,7 +47,7 @@ jobs:
       packages: write # allow GITHUB_TOKEN to publish packages
     strategy:
       matrix:
-        source: [github, npmjs]
+        source: [github]
         include:
           - source: github
             registry-url: https://npm.pkg.github.com/

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -42,6 +42,9 @@ jobs:
 
   test-npm:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # allow GITHUB_TOKEN to publish packages
     strategy:
       matrix:
         source: [github, npmjs]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
             registry-url: https://npm.pkg.github.com/
             scope: 'kagekirin'                        #must be lowercase, without '@'
             username: ${{ github.repository_owner }}  #not lowercase
-            token: GH_NPM_TOKEN
+            token: GITHUB_TOKEN
     needs: test-npm
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       packages: write # allow GITHUB_TOKEN to publish packages
     strategy:
       matrix:
-        source: [github, npmjs]
+        source: [github]
         include:
           - source: github
             registry-url: https://npm.pkg.github.com/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,11 +49,6 @@ jobs:
             scope: 'kagekirin'                        #must be lowercase, without '@'
             username: ${{ github.repository_owner }}  #not lowercase
             token: GH_NPM_TOKEN
-          - source: npmjs
-            registry-url: https://registry.npmjs.org/
-            scope: 'kagekirin'                        #must be lowercase, without '@'
-            username: ${{ github.repository_owner }}  #not lowercase
-            token: NPMJS_ORG_TOKEN
     needs: test-npm
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,10 @@ jobs:
 
   npm:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # allow GITHUB_TOKEN to publish packages
+      packages: write
     strategy:
       matrix:
         source: [github, npmjs]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,11 +20,6 @@ jobs:
             scope: 'kagekirin'                        #must be lowercase, without '@'
             username: ${{ github.repository_owner }}  #not lowercase
             token: GH_NPM_TOKEN
-          - source: npmjs
-            registry-url: https://registry.npmjs.org/
-            scope: 'kagekirin'                        #must be lowercase, without '@'
-            username: ${{ github.repository_owner }}  #not lowercase
-            token: NPMJS_ORG_TOKEN
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
     - id: npm-prepare-publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
             registry-url: https://npm.pkg.github.com/
             scope: 'kagekirin'                        #must be lowercase, without '@'
             username: ${{ github.repository_owner }}  #not lowercase
-            token: GH_NPM_TOKEN
+            token: GITHUB_TOKEN
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
     - id: npm-prepare-publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   test-npm:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # allow GITHUB_TOKEN to publish packages
     strategy:
       matrix:
         source: [github, npmjs]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        source: [github, npmjs]
+        source: [github]
         include:
           - source: github
             registry-url: https://npm.pkg.github.com/


### PR DESCRIPTION
- **refactor ('build-ci' workflow): add package-write permissions to 'test-npm' job**
- **refactor ('build-cron' workflow): add package-write permissions to 'test-npm' job**
- **refactor ('build-pr' workflow): add package-write permissions to 'test-npm' job**
- **refactor ('publish' workflow): add package-write permissions to 'test-npm' job**
- **refactor ('publish' workflow): add package-write permissions to 'npm' job**
- **refactor ('build-ci' workflow): remove 'npmjs' fromfrom 'test-npm' job matrix options**
- **refactor ('build-cron' workflow): remove 'npmjs' fromfrom 'test-npm' job matrix options**
- **refactor ('build-pr' workflow): remove 'npmjs' fromfrom 'test-npm' job matrix options**
- **refactor ('publish' workflow): remove 'npmjs' fromfrom 'test-npm' job matrix options**
- **refactor ('publish' workflow): remove 'npmjs' fromfrom 'npm' job matrix options**
- **refactor ('build-ci' workflow): remove parameters for 'npmjs' from 'test-npm' job matrix**
- **refactor ('build-cron' workflow): remove parameters for 'npmjs' from 'test-npm' job matrix**
- **refactor ('build-pr' workflow): remove parameters for 'npmjs' from 'test-npm' job matrix**
- **refactor ('publish' workflow): remove parameters for 'npmjs' from 'test-npm' job matrix**
- **refactor ('publish' workflow): remove parameters for 'npmjs' from 'npm' job matrix**
- **refactor ('build-ci' workflow): replace GH_NPM_TOKEN with internal GITHUB_TOKEN in 'test-npm' job**
- **refactor ('build-cron' workflow): replace GH_NPM_TOKEN with internal GITHUB_TOKEN in 'test-npm' job**
- **refactor ('build-pr' workflow): replace GH_NPM_TOKEN with internal GITHUB_TOKEN in 'test-npm' job**
- **refactor ('publish' workflow): replace GH_NPM_TOKEN with internal GITHUB_TOKEN in 'test-npm' job**
- **refactor ('publish' workflow): replace GH_NPM_TOKEN with internal GITHUB_TOKEN in 'npm' job**
