### PR TITLE
refactor ('release' workflow): fix argument passed to 'gha-utils/gh-create-release' .files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,6 @@ jobs:
           title: Release ${{ github.action_ref }}
           generate-notes: true
           files: |
-            ${{ steps.npm-pack.outputs.artifacts }}
+            ${{ steps.npm-pack.outputs.package-full }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
details: pass ${{ steps.npm-pack.outputs.package-full }} or ${{ steps.npm-pack.outputs.package }}
         instead of ${{ steps.npm-pack.outputs.artifacts }}, which does not exist.
